### PR TITLE
Add addDependencyMaven task

### DIFF
--- a/src/main/scala/com/blstream/sbtsearchmavenplugin/SbtSearchMavenPlugin.scala
+++ b/src/main/scala/com/blstream/sbtsearchmavenplugin/SbtSearchMavenPlugin.scala
@@ -3,18 +3,20 @@ package com.blstream.sbtsearchmavenplugin
 import sbt._
 import sbt.Keys.{ streams, aggregate }
 
-object SbtSearchMavenPlugin extends AutoPlugin with SearchWithDependencies {
+object SbtSearchMavenPlugin extends AutoPlugin with SearchWithDependencies with SearchAndAddDependency {
 
   override def trigger = allRequirements
 
   object autoImport {
     lazy val searchMaven = InputKey[Unit]("searchMaven", "Search maven")
+    lazy val addDependencyMaven = InputKey[Unit]("addDependencyMaven", "Add a dependency from maven")
   }
 
   import autoImport._
 
   override lazy val projectSettings = Seq(
     searchMaven := search(complete.DefaultParsers.spaceDelimited("<arg>").parsed, streams.value.log),
+    addDependencyMaven := add(complete.DefaultParsers.spaceDelimited("<arg>").parsed, streams.value.log),
     aggregate in searchMaven := false
   )
 
@@ -26,3 +28,11 @@ trait SearchWithDependencies
   with QueryCleaner
   with ResultsParser
   with ArtifactsPrinter
+
+trait SearchAndAddDependency
+  extends AddDependency
+  with SearchWithDependencies
+  with ArtifactString
+  with sbt.PathExtra
+  with DependencyReaderWriter
+

--- a/src/main/scala/com/blstream/sbtsearchmavenplugin/SelectDependency.scala
+++ b/src/main/scala/com/blstream/sbtsearchmavenplugin/SelectDependency.scala
@@ -1,0 +1,50 @@
+/* This code is mostly based on SelectMainClass.scala written by
+ * Mark Harrah in 2009 for the sbt project.
+ */
+
+package com.blstream.sbtsearchmavenplugin
+
+object SelectDependency extends ArtifactsPrinter {
+  // Some(SimpleReader.readLine _)
+  def apply(artifacts: Seq[Artifact], promptIfMultipleChoices: Option[String => Option[String]]): Option[Artifact] = {
+    artifacts.toList match {
+      case Nil => None
+      case head :: Nil => Some(head)
+      case multiple =>
+        promptIfMultipleChoices flatMap { prompt =>
+          println("\nMultiple dependencies detected, select one to be used:\n")
+          println(printArtifacts("query")(artifacts.toList))
+          val line = trim(prompt("\nEnter number: "))
+          println("")
+          toInt(line, multiple.length) map multiple.apply
+        }
+    }
+  }
+
+  private final val LIBRARY_DEPENDENCY_STRING: String = "libraryDependencies += "
+
+  private def artifactToString(artifact: Artifact): String = {
+    artifact match {
+      case Artifact(a, g, v) => s"""$LIBRARY_DEPENDENCY_STRING"%s" %% "%s" %% "%s"""".format(a, g, v)
+      case _ => ""
+    }
+  }
+
+  private def trim(s: Option[String]) = s.getOrElse("")
+
+  private def toInt(s: String, size: Int) =
+    try {
+      val i = s.toInt
+      if (i > 0 && i <= size)
+        Some(i - 1)
+      else {
+        println("Number out of range: was " + i + ", expected number between 1 and " + size)
+        None
+      }
+    } catch {
+      case nfe: NumberFormatException =>
+        println("Invalid number: " + nfe.toString)
+        None
+    }
+
+}

--- a/src/main/scala/com/blstream/sbtsearchmavenplugin/addDependency.scala
+++ b/src/main/scala/com/blstream/sbtsearchmavenplugin/addDependency.scala
@@ -1,0 +1,92 @@
+package com.blstream.sbtsearchmavenplugin
+
+import sbt.{ Project, SimpleReader, Logger }
+
+import java.io.{ PrintWriter, File }
+
+trait AddDependency {
+  self: Search with DependencyReaderWriter with ArtifactString =>
+
+  def add(args: Seq[String], log: Logger): Unit = {
+    val artifact = getAndChooseArtifacts(args, inputFunction)
+    artifact.right.map(writeArtifactsFile(_))
+
+    artifact.fold(
+      log.warn(_),
+      log.info(_)
+    )
+  }
+
+  def getAndChooseArtifacts(args: Seq[String], chooseFn: Option[String => Option[String]]): Either[Error, Artifact] = {
+    getResultsFor(args) match {
+      case Right((cleanedQuery, artifacts)) => chooseArtifact(artifacts, chooseFn)
+      case _ => Left("Couldn't find any dependency")
+    }
+  }
+
+  def chooseArtifact(artifacts: Seq[Artifact], chooseFn: Option[String => Option[String]]): Either[Error, Artifact] = {
+    SelectDependency(artifacts, chooseFn) match {
+      case Some(artifact: Artifact) => Right(artifact)
+      case _ => Left("")
+    }
+  }
+
+  def inputFunction: Option[String => Option[String]] = Some(SimpleReader readLine _)
+}
+
+trait ArtifactString {
+  final val LIBRARY_DEPENDENCY_STRING: String = "libraryDependencies += "
+  final val LIBRARY_DEPENDENCY_REGEX: String = "libraryDependencies \\+= "
+
+  implicit def artifactToString(artifact: Artifact): String = {
+    artifact match {
+      case Artifact(a, g, v) => s"""$LIBRARY_DEPENDENCY_STRING"%s" %% "%s" %% "%s"""".format(a, g, v)
+      case _ => ""
+    }
+  }
+
+  implicit def stringToArtifact(str: String): Artifact = {
+    str.replaceFirst(s"$LIBRARY_DEPENDENCY_REGEX", "").split('%').map(_.trim).toSeq match {
+      case Seq(s: String, g: String, v: String) => Artifact(s.replaceAll("\"", ""), g.replaceAll("\"", ""), v.replaceAll("\"", ""))
+      case _ => Artifact("", "", "")
+    }
+  }
+}
+
+trait DependencyReaderWriter {
+  self: ArtifactString with sbt.PathExtra =>
+
+  val artifactFile: File = Project("root", new File(".")).base / "artifacts.sbt"
+
+  implicit def artifactsToFileString(artifacts: Seq[Artifact]): String = artifacts.map(a => a: String).mkString("\n")
+
+  def writeArtifactsFile(artifact: Artifact): Unit = {
+    val artifacts = readArtifactsFile match {
+      case Some(artifacts: List[Artifact]) => insert(artifacts, artifact)
+      case None => List(artifact)
+    }
+    val writer = new PrintWriter(artifactFile)
+    writer.write(artifacts: String)
+    writer.close()
+  }
+
+  private def insert(artifacts: List[Artifact], artifact: Artifact): List[Artifact] = {
+    artifacts.filter(a => a == artifact) match {
+      case List() => artifacts ::: List(artifact)
+      case _ => artifacts
+    }
+  }
+
+  def readArtifactsFile: Option[List[Artifact]] = {
+    val sbtArtifactFormat = s"""$LIBRARY_DEPENDENCY_REGEX".*" \\% ".*" \\% ".*""""
+    try {
+      val foundArtifacts = scala.io.Source.fromFile(artifactFile)
+        .getLines.filter(s => s.matches(sbtArtifactFormat))
+        .map(a => a: Artifact).toList
+      if (foundArtifacts.length > 0) Some(foundArtifacts)
+      else None
+    } catch {
+      case _: Throwable => None
+    }
+  }
+}

--- a/src/test/scala/com/blstream/sbtsearchmavenplugin/AddDependencyTest.scala
+++ b/src/test/scala/com/blstream/sbtsearchmavenplugin/AddDependencyTest.scala
@@ -1,0 +1,40 @@
+package com.blstream.sbtsearchmavenplugin
+
+import org.specs2.mutable.Specification
+import org.specs2.specification.{ AfterEach, BeforeEach }
+
+class AddDependencyTest extends Specification with BeforeEach with AfterEach with AddDependencyTraits {
+  sequential
+
+  val chooseSequence = Seq(1, 2, 1)
+
+  val artifacts = List(Artifact("org.scalaz", "z", "1"), Artifact("foo", "bar", "baz"))
+
+  "chooseArtifact" should {
+    "allow a user to pick the chosen artifact out of a list of artifacts" >> {
+      val chosenArtifacts = chooseSequence map (i => chooseArtifact(artifacts, choose(i)))
+      val expectedArtifacts = chooseSequence map (i => Right(artifacts(i - 1)))
+      expectedArtifacts must beEqualTo(chosenArtifacts)
+    }
+  }
+
+  def choose(index: Integer): Option[String => Option[String]] = {
+    def chooseIndex(str: String): Option[String] = {
+      Some(s"""$index""")
+    }
+    Some(chooseIndex)
+  }
+}
+
+trait AddDependencyTraits
+  extends AddDependency
+  with Search
+  with MavenOrgSearcher
+  with QueryCleaner
+  with ResultsParser
+  with ArtifactsPrinter
+  with DependencyReaderWriter
+  with ArtifactString
+  with sbt.PathExtra
+  with ArtifactFileHelper
+

--- a/src/test/scala/com/blstream/sbtsearchmavenplugin/ArtifactFileHelper.scala
+++ b/src/test/scala/com/blstream/sbtsearchmavenplugin/ArtifactFileHelper.scala
@@ -1,0 +1,35 @@
+package com.blstream.sbtsearchmavenplugin
+
+import java.io.PrintWriter
+
+trait ArtifactFileHelper {
+  self: DependencyReaderWriter =>
+
+  def getFileContents: String = {
+    val string = try {
+      scala.io.Source.fromFile(artifactFile).getLines.mkString("\n")
+    } catch {
+      case _: Throwable => ""
+    }
+    string
+  }
+
+  def createEmptyFile: Unit = artifactFile.createNewFile()
+
+  def createFileWithContents(contents: String): Unit = {
+    createEmptyFile
+    val writer = new PrintWriter(artifactFile)
+
+    writer.write(contents)
+    writer.close()
+  }
+
+  def before = {
+    try {
+      artifactFile.delete()
+    } catch {
+      case (_: Throwable) =>
+    }
+  }
+  def after = before
+}

--- a/src/test/scala/com/blstream/sbtsearchmavenplugin/ArtifactsPrinterTest.scala
+++ b/src/test/scala/com/blstream/sbtsearchmavenplugin/ArtifactsPrinterTest.scala
@@ -15,9 +15,9 @@ class ArtifactsPrinterTest extends Specification
       val text = printArtifacts("foo")(artifacts)
       val expectedResult =
         s"""Results for foo:
-           |"org.scalaz" % "z"     % "1"
-           |"foo"        % "bar"   % "baz"
-           |"some"       % "other" % "2"""".stripMargin
+           |[0] "org.scalaz" % "z"     % "1"
+           |[1] "foo"        % "bar"   % "baz"
+           |[2] "some"       % "other" % "2"""".stripMargin
 
       text must beEqualTo(expectedResult)
     }

--- a/src/test/scala/com/blstream/sbtsearchmavenplugin/DependencyReaderWriterTest.scala
+++ b/src/test/scala/com/blstream/sbtsearchmavenplugin/DependencyReaderWriterTest.scala
@@ -1,0 +1,89 @@
+package com.blstream.sbtsearchmavenplugin
+
+import org.specs2.mutable.Specification
+import org.specs2.specification.{ AfterEach, BeforeEach }
+
+class DependencyReaderWriterTest
+    extends Specification
+    with BeforeEach with AfterEach
+    with DependencyReaderWriterTraits {
+
+  val artifacts = Seq(
+    Artifact("org.scalaz", "z", "1"),
+    Artifact("foo", "bar", "baz")
+  )
+
+  sequential
+
+  "writeArtifactsFile" should {
+    "properly write a single artifact to an non existing artifact file" >> {
+      val artifact = artifacts(0)
+      writeArtifactsFile(artifact)
+      val text = getFileContents
+      val expectedResult =
+        s"""|libraryDependencies += "org.scalaz" % "z" % "1"""".stripMargin
+
+      text must beEqualTo(expectedResult)
+    }
+  }
+
+  "writeArtifactsFile" should {
+    "be able to add artifacts to an existing file" >> {
+      artifacts.map(writeArtifactsFile)
+      val text = getFileContents
+      val expectedResult =
+        s"""|libraryDependencies += "org.scalaz" % "z" % "1"
+            |libraryDependencies += "foo" % "bar" % "baz"""".stripMargin
+
+      text must beEqualTo(expectedResult)
+    }
+  }
+
+  "writeArtifactsFile" should {
+    "not add duplicates in a file" >> {
+      artifacts.map(writeArtifactsFile)
+      writeArtifactsFile(artifacts.head)
+      val text = getFileContents
+      val expectedResult =
+        s"""|libraryDependencies += "org.scalaz" % "z" % "1"
+           |libraryDependencies += "foo" % "bar" % "baz"""".stripMargin
+
+      text must beEqualTo(expectedResult)
+    }
+  }
+
+  "readArtifactsFile" should {
+    "work even with a non existent file" >> {
+      val artifacts = readArtifactsFile
+      artifacts must beNone
+    }
+  }
+
+  "readArtifactsFile" should {
+    "work even with an empty file" >> {
+      createEmptyFile
+      val artifacts = readArtifactsFile
+      artifacts must beNone
+    }
+  }
+
+  "readArtifactsFile" should {
+    "work with a corrupted file" >> {
+      val corruptedFileContents =
+        s"""+= "org.scalaz" % "z" % "1"
+           |libraryDependencies += "foo" % "bar" % "baz"
+           |libraryDependencies += "foo" %  % "buz"
+           |"baz"""".stripMargin
+      createFileWithContents(corruptedFileContents)
+      val artifacts = readArtifactsFile
+      println(artifacts)
+      artifacts mustEqual Some(Seq(Artifact("foo", "bar", "baz")))
+    }
+  }
+}
+
+trait DependencyReaderWriterTraits
+  extends DependencyReaderWriter
+  with ArtifactString
+  with sbt.PathExtra
+  with ArtifactFileHelper


### PR DESCRIPTION
This task adds the capability of persisting found artifacts
as project dependencies. The dependencies are persisted in
the file artifacts.sbt in the project root.

Example usage and output: 
```
> addDependencyMaven akka-actor

Multiple dependencies detected, select one to be used:

Results for query:
[0] "com.typesafe.akka"      % "akka-actor-tests_2.10"       % "2.3.15"
[1] "com.typesafe.akka"      % "akka-actor-tests_2.11"       % "2.4-M2"
[2] "org.spark-project"      % "akka-actor"                  % "2.0.5-protobuf-2.5-java-1.5"
[3] "com.typesafe.akka"      % "akka-actor-tests_2.12.0-M1"  % "2.4-M2"
[4] "com.typesafe.akka"      % "akka-actor-tests_2.11.0-RC4" % "2.3.0"
[5] "com.typesafe.akka"      % "akka-actor-tests_2.11.0-RC3" % "2.3.0"
[6] "com.typesafe.akka"      % "akka-actor-tests_2.11.0-M3"  % "2.2.0"
[7] "com.typesafe.akka"      % "akka-actor_2.12.0-M4"        % "2.4.4"
[8] "com.typesafe.akka"      % "akka-actor_2.11"             % "2.4.4"
[9] "com.typesafe.akka"      % "akka-actor_2.12.0-M3"        % "2.4.3"
[10] "com.typesafe.akka"      % "akka-actor_2.10"             % "2.3.15"
[11] "com.typesafe.akka"      % "akka-actor_2.12.0-M2"        % "2.4.0"
[12] "com.typesafe.akka"      % "akka-actor_2.12.0-M1"        % "2.4-M2"
[13] "com.liveperson"         % "akka-actor-x"                % "0.1.1"
[14] "org.spark-project.akka" % "akka-actor_2.11"             % "2.3.4-spark"
[15] "org.spark-project.akka" % "akka-actor_2.10"             % "2.3.4-spark"
[16] "com.typesafe.akka"      % "akka-actor_2.11.0-RC4"       % "2.3.0"
[17] "com.typesafe.akka"      % "akka-actor_2.11.0-RC3"       % "2.3.0"
[18] "com.typesafe.akka"      % "akka-actor_2.11.0-RC1"       % "2.3.0-RC4"
[19] "com.deploymentzone"     % "akka-actor-statsd_2.10"      % "0.1"

Enter number: 8

[info] libraryDependencies += "com.typesafe.akka" % "akka-actor_2.12.0-M4" % "2.4.4"
[success] Total time: 12 s, completed 21.04.2016 19:39:41
```
